### PR TITLE
Add instructions, export tryCompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.1
+
+* Exposed the `tryCompletion` method as a public interface.
+
+* Added more complete instructions in the [`README.md`](README.md)
+
 ## 0.2.0
 
 * Renamed `COMPLETION_COMMAND_NAME` to `completionCommandName`.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,43 @@
 
 [![Build Status](https://travis-ci.org/kevmoo/completion.dart.svg?branch=master)](https://travis-ci.org/kevmoo/completion.dart)
 [![Coverage Status](https://coveralls.io/repos/kevmoo/completion.dart/badge.svg?branch=master)](https://coveralls.io/r/kevmoo/completion.dart)
+
+To use this package, instead of this:
+
+```dart
+import 'packages:args/args.dart';
+
+void main(List<String> args) {
+  ArgParser argParser = new ArgParser();
+  argParser.addFlag('option', help: 'flag help');
+  // ... add more options ...
+  ArgResults argResults = argParser.parse(args);
+  // ...
+}
+```
+
+do this:
+
+```dart
+import 'packages:args/args.dart';
+import 'packages:completion/completion.dart' as completion;
+
+void main(List<String> args) {
+  ArgParser argParser = new ArgParser();
+  argParser.addFlag('option', help: 'flag help');
+  // ... add more options ...
+  ArgResults argResults = completion.tryArgsCompletion(args, argParser);
+  // ...
+}
+```
+
+(The only difference is calling `complete.tryArgsCompletion` in place of `argParser.parse`)
+
+This will add a "completion" command to your app, which the shell will use
+to complete arguments.
+
+To generate the setup script automatically, call `generateCompletionScript`
+with the names of the executables that your Dart script runs as (typically
+just one, but it could be more).
+
+Also, see [the example](./example).

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -4,6 +4,7 @@ import 'src/get_args_completions.dart';
 import 'src/try_completion.dart';
 
 export 'src/generate.dart';
+export 'src/try_completion.dart';
 
 ArgResults tryArgsCompletion(
     List<String> mainArgs,

--- a/lib/src/try_completion.dart
+++ b/lib/src/try_completion.dart
@@ -43,15 +43,8 @@ void tryCompletion(
   String scriptName;
   try {
     scriptName = p.basename(Platform.script.toFilePath());
-  } on UnsupportedError catch (e, stack) {
-    log(e);
-    log(stack);
-    return;
-  }
-
-  if (scriptName.isEmpty) {
-    // should have a script name...weird...
-    return;
+  } on UnsupportedError catch (e) {
+    scriptName = '<unknown>';
   }
 
   log('Checking for completion on script:\t$scriptName');

--- a/lib/src/try_completion.dart
+++ b/lib/src/try_completion.dart
@@ -18,7 +18,7 @@ const _compPointVar = 'COMP_POINT';
 void tryCompletion(
     List<String> args,
     List<String> completer(List<String> args, String compLine, int compPoint),
-    {@Deprecated('Useful for testing, but do not released with this set.')
+    {@Deprecated('Useful for testing, but do not release with this set.')
         logFile}) {
   if (logFile != null) {
     var logFile = new File('_completion.log');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: completion
-version: 0.2.0
+version: 0.2.1
 author: Kevin Moore <github@j832.com>
 description: A packaged to add shell command completion to your Dart application
 homepage: https://github.com/kevmoo/completion.dart


### PR DESCRIPTION
Hi Kevin,

In using this, I realized that it would be more convenient for my usage if I could have direct access to `tryCompletion` instead of having `tryArgsCompletion` call `argParser.parse` itself, since that means I have to override `parse` in the `CommandRunner` in the args package in order to inject the completion code.

I removed some returns when it fails to get a script name in `tryCompletion`, since that's only used for log output, and it prevents testing that completion actually works in Flutter's test environment (the script name is a data URL in that case).

I also added some instructions to the readme, since that seems like it would help people use this.  Hopefully they're close... :-)