### PR TITLE
Fix lint error

### DIFF
--- a/lib/src/try_completion.dart
+++ b/lib/src/try_completion.dart
@@ -43,7 +43,7 @@ void tryCompletion(
   String scriptName;
   try {
     scriptName = p.basename(Platform.script.toFilePath());
-  } on UnsupportedError catch (e) {
+  } on UnsupportedError {
     scriptName = '<unknown>';
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: completion
-version: 0.2.2
+version: 0.2.1+1
 author: Kevin Moore <github@j832.com>
 description: A packaged to add shell command completion to your Dart application
 homepage: https://github.com/kevmoo/completion.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: completion
-version: 0.2.1
+version: 0.2.2
 author: Kevin Moore <github@j832.com>
 description: A packaged to add shell command completion to your Dart application
 homepage: https://github.com/kevmoo/completion.dart


### PR DESCRIPTION
ERROR: third_party/dart/completion/lib/src/try_completion.dart:46
  The exception variable 'e' isn't used, so the 'catch' clause can be removed. #unused_catch_clause
