### PR TITLE
catch FileSystemException from missing current working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3
+
+* Prevent `tryCompletion` from crashing when looking up the script name when run
+  without a current working directory.
+
 ## 0.2.2
 
 * Increase minimum Dart SDK to `2.3.0`.

--- a/lib/src/try_completion.dart
+++ b/lib/src/try_completion.dart
@@ -46,6 +46,9 @@ void tryCompletion(
   String scriptName;
   try {
     scriptName = p.basename(Platform.script.toFilePath());
+  } on FileSystemException {
+    // Script may not have a current working directory.
+    scriptName = '<unknown>';
   } on UnsupportedError // ignore: avoid_catching_errors
   {
     scriptName = '<unknown>';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: completion
-version: 0.2.2
+version: 0.2.3
 description: A packaged to add shell command completion to your Dart application
 homepage: https://github.com/kevmoo/completion.dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: completion
 version: 0.2.3
-description: A packaged to add shell command completion to your Dart application
+description: A package to add shell command completion to your Dart application
 homepage: https://github.com/kevmoo/completion.dart
 
 environment:


### PR DESCRIPTION
I'm seeing a small, but non-trivial number of crashes coming from args completion in the flutter tool. The crashes look like:


```
FileSystemException: FileSystemException: Getting current working directory failed, path = '' (OS Error: No such file or directory, errno = 2)

at _uriBaseClosure | (directory_patch.dart:64)
-- | --
  | at Uri.base | (uri_patch.dart:21)
  | at _Platform._nativeScript=.<anonymous closure> | (platform_patch.dart:55)
  | at VMLibraryHooks.platformScript | (internal_patch.dart:99)
  | at _Platform._script | (platform_patch.dart:41)
  | at _Platform.script | (platform_impl.dart:59)
  | at Platform.script | (platform.dart:189)
  | at tryCompletion | (try_completion.dart:47)
  | at tryArgsCompletion | (completion.dart:14)
  | at FlutterCommandRunner.parse | (flutter_command_runner.dart:157)
  | at CommandRunner.run.<anonymous closure> | (command_runner.dart:112)
  | at new Future.sync | (future.dart:223)
  | at CommandRunner.run | (command_runner.dart:112)
  | at FlutterCommandRunner.run | (flutter_command_runner.dart:181)
  | at run.<anonymous closure>.<anonymous closure> | (runner.dart:63)
  | at run.<anonymous closure>.<anonymous closure> | (runner.dart:61)
  | at _rootRun | (zone.dart:1190)
  | at _CustomZone.run | (zone.dart:1093)
  | at _runZoned | (zone.dart:1630)
  | at runZonedGuarded | (zone.dart:1618)
  | at runZoned | (zone.dart:1547)
  | at run.<anonymous closure> | (runner.dart:61)
  | at <asynchronous gap> | (async)
  | at AppContext.run.<anonymous closure> | (context.dart:150)
  | at <asynchronous gap> | (async)
  | at AppContext.run | (context.dart:149)
  | at <asynchronous gap> | (async)
  | at runInContext | (context_runner.dart:70)
  | at <asynchronous gap> | (async)
  | at main | (executable.dart:90)
  | at <asynchronous gap> | (async)
```

I don't think the script name is important to the autocompletion?