### PR TITLE
🧪 [test improvement] Add test for exception handling in tryCompletionImpl

### DIFF
--- a/test/env_var_test.dart
+++ b/test/env_var_test.dart
@@ -42,5 +42,13 @@ void main() {
       );
       expect(exitCode, isNull);
     });
+
+    test('exception in completer returns 1', () {
+      final args = ['completion', '--', 'exe', 'a'];
+      final exitCode = tryCompletionImpl(args, (a, l, p) {
+        throw StateError('Test exception');
+      }, environment: {'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
+      expect(exitCode, 1);
+    });
   });
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the `catch` block inside `tryCompletionImpl` in `lib/src/try_completion.dart:128` was completely untested. This block handles any exceptions thrown by the `completer` function.
📊 **Coverage:** A test case was added to `test/env_var_test.dart` that explicitly passes a `completer` function that throws a `StateError` and asserts that `tryCompletionImpl` correctly catches it and returns an exit code of `1`.
✨ **Result:** The improvement in test coverage is that the exception handling path in `tryCompletionImpl` is now explicitly verified, preventing regressions where a throwing completer could crash the application instead of gracefully returning `1`.

---
*PR created automatically by Jules for task [9119379420765227273](https://jules.google.com/task/9119379420765227273) started by @kevmoo*