### PR TITLE
⚡ Remove unnecessary List allocations in completions

### DIFF
--- a/benchmark/get_args_completions_benchmark.dart
+++ b/benchmark/get_args_completions_benchmark.dart
@@ -1,4 +1,3 @@
-import 'package:args/args.dart';
 import 'package:completion/src/get_args_completions.dart';
 import '../test/completion_tests_args.dart';
 
@@ -17,7 +16,7 @@ void main() {
 
   final watch = Stopwatch()..start();
   for (var i = 0; i < iterations; i++) {
-    getArgsCompletions(parser, args, compLine, compPoint);
+    getArgsCompletions(parser, args, compLine, compPoint).toList();
   }
   watch.stop();
 

--- a/benchmark/get_args_completions_benchmark.dart
+++ b/benchmark/get_args_completions_benchmark.dart
@@ -1,0 +1,27 @@
+import 'package:args/args.dart';
+import 'package:completion/src/get_args_completions.dart';
+import '../test/completion_tests_args.dart';
+
+void main() {
+  final parser = getHelloSampleParser();
+  final args = ['--friendly', '--salutation', 'Mr', 'help', ''];
+  final compLine = args.join(' ');
+  final compPoint = compLine.length;
+
+  const iterations = 100000;
+
+  // Warmup
+  for (var i = 0; i < 10000; i++) {
+    getArgsCompletions(parser, args, compLine, compPoint);
+  }
+
+  final watch = Stopwatch()..start();
+  for (var i = 0; i < iterations; i++) {
+    getArgsCompletions(parser, args, compLine, compPoint);
+  }
+  watch.stop();
+
+  print('Iterations: $iterations');
+  print('Total time: ${watch.elapsedMilliseconds}ms');
+  print('Average time: ${watch.elapsedMicroseconds / iterations}us');
+}

--- a/benchmark/get_args_completions_benchmark.dart
+++ b/benchmark/get_args_completions_benchmark.dart
@@ -11,7 +11,7 @@ void main() {
 
   // Warmup
   for (var i = 0; i < 10000; i++) {
-    getArgsCompletions(parser, args, compLine, compPoint);
+    getArgsCompletions(parser, args, compLine, compPoint).toList();
   }
 
   final watch = Stopwatch()..start();

--- a/lib/src/get_args_completions.dart
+++ b/lib/src/get_args_completions.dart
@@ -14,7 +14,7 @@ import 'util.dart';
 /// the completion suggestions.
 /// (Hidden commands are always included.)
 @internal
-List<String> getArgsCompletions(
+Iterable<String> getArgsCompletions(
   ArgParser parser,
   List<String> providedArgs,
   String compLine,
@@ -50,12 +50,9 @@ List<String> getArgsCompletions(
 
   if (providedArgs.isEmpty) {
     sublog('empty args. Complete with all available commands');
-    return parser.commands.keys.toList();
+    return parser.commands.keys;
   }
 
-  final alignedArgsOptions = providedArgs
-      .map((arg) => _getOptionForArg(parser, arg))
-      .toList();
 
   /*
    * NOTE: nuanced behavior
@@ -70,11 +67,14 @@ List<String> getArgsCompletions(
 
   // a set of options in use (minus, potentially, the last one)
   // all non-null, all unique
-  final optionsDefinedInArgs = alignedArgsOptions
-      .take(alignedArgsOptions.length - 1)
+  final optionsDefinedInArgs = providedArgs
+      .take(providedArgs.length - 1)
+      .map((arg) => _getOptionForArg(parser, arg))
       .whereType<Option>()
       .toSet();
-  sublog('defined options: ${optionsDefinedInArgs.map((o) => o.name).toSet()}');
+  sublog(
+    'defined options: ${optionsDefinedInArgs.map((Option o) => o.name).toSet()}',
+  );
 
   final parserOptionCompletions = List<String>.unmodifiable(
     _parserOptionCompletions(
@@ -180,7 +180,7 @@ List<String> getArgsCompletions(
     if (compLine.endsWith(' ')) {
       // if the removed item maps to an option w/ allowed values
       // we should return those values to complete against
-      final option = alignedArgsOptions[providedArgs.length - 1];
+      final option = _getOptionForArg(parser, providedArgs.last);
       if (option != null &&
           option.allowed != null &&
           option.allowed!.isNotEmpty) {
@@ -188,14 +188,13 @@ List<String> getArgsCompletions(
 
         sublog('completing all allowed value for option "${option.name}"');
 
-        return option.allowed!.toList();
+        return option.allowed!;
       }
     } else {
       sublog('completing the name of options starting with "$removedItem"');
 
       return parserOptionCompletions
-          .where((String option) => option.startsWith(removedItem))
-          .toList();
+          .where((String option) => option.startsWith(removedItem));
     }
   }
 
@@ -204,7 +203,7 @@ List<String> getArgsCompletions(
    * then we should complete with the available options, right?
    */
   if (providedArgs.length >= 2) {
-    final option = alignedArgsOptions[providedArgs.length - 2];
+    final option = _getOptionForArg(parser, providedArgs[providedArgs.length - 2]);
     if (option != null) {
       if (option.allowed != null && option.allowed!.isNotEmpty) {
         assert(!option.isFlag);
@@ -212,7 +211,7 @@ List<String> getArgsCompletions(
 
         final optionValue = providedArgs[providedArgs.length - 1];
 
-        return option.allowed!.where((v) => v.startsWith(optionValue)).toList();
+        return option.allowed!.where((String v) => v.startsWith(optionValue));
       } else if (!option.isFlag) {
         sublog('not providing completions. Waiting for option value');
         return const [];
@@ -227,7 +226,7 @@ List<String> getArgsCompletions(
   if (removedItems.isEmpty && lastArg == '') {
     sublog('doing command completion');
 
-    return parser.commands.keys.toList();
+    return parser.commands.keys;
   }
 
   /*
@@ -248,8 +247,7 @@ List<String> getArgsCompletions(
     sublog('completing command names that start with "$lastArg"');
 
     return parser.commands.keys
-        .where((String commandName) => commandName.startsWith(lastArg))
-        .toList();
+        .where((String commandName) => commandName.startsWith(lastArg));
   }
 
   /*
@@ -307,7 +305,7 @@ Iterable<String> _parserOptionCompletions(
 
   return parser.options.values
       .where(
-        (opt) =>
+        (Option opt) =>
             (includeHidden || !opt.hide) &&
             (!existingOptions.contains(opt) || opt.type == OptionType.multiple),
       )

--- a/lib/src/get_args_completions.dart
+++ b/lib/src/get_args_completions.dart
@@ -53,7 +53,6 @@ Iterable<String> getArgsCompletions(
     return parser.commands.keys;
   }
 
-
   /*
    * NOTE: nuanced behavior
    * If the last item provided is a full, real item (command or option)
@@ -73,7 +72,8 @@ Iterable<String> getArgsCompletions(
       .whereType<Option>()
       .toSet();
   sublog(
-    'defined options: ${optionsDefinedInArgs.map((Option o) => o.name).toSet()}',
+    'defined options: '
+    '${optionsDefinedInArgs.map((Option o) => o.name).toSet()}',
   );
 
   final parserOptionCompletions = List<String>.unmodifiable(
@@ -193,8 +193,9 @@ Iterable<String> getArgsCompletions(
     } else {
       sublog('completing the name of options starting with "$removedItem"');
 
-      return parserOptionCompletions
-          .where((String option) => option.startsWith(removedItem));
+      return parserOptionCompletions.where(
+        (String option) => option.startsWith(removedItem),
+      );
     }
   }
 
@@ -203,7 +204,10 @@ Iterable<String> getArgsCompletions(
    * then we should complete with the available options, right?
    */
   if (providedArgs.length >= 2) {
-    final option = _getOptionForArg(parser, providedArgs[providedArgs.length - 2]);
+    final option = _getOptionForArg(
+      parser,
+      providedArgs[providedArgs.length - 2],
+    );
     if (option != null) {
       if (option.allowed != null && option.allowed!.isNotEmpty) {
         assert(!option.isFlag);
@@ -246,8 +250,9 @@ Iterable<String> getArgsCompletions(
 
     sublog('completing command names that start with "$lastArg"');
 
-    return parser.commands.keys
-        .where((String commandName) => commandName.startsWith(lastArg));
+    return parser.commands.keys.where(
+      (String commandName) => commandName.startsWith(lastArg),
+    );
   }
 
   /*

--- a/lib/src/try_completion.dart
+++ b/lib/src/try_completion.dart
@@ -32,7 +32,7 @@ const _compPointVar = 'COMP_POINT';
 /// in production code.
 int? tryCompletion(
   List<String> args,
-  List<String> Function(List<String> args, String compLine, int compPoint)
+  Iterable<String> Function(List<String> args, String compLine, int compPoint)
   completer, {
   @Deprecated('Useful for testing, but do not release with this set.')
   bool? logFile,
@@ -41,7 +41,7 @@ int? tryCompletion(
 @internal
 int? tryCompletionImpl(
   List<String> args,
-  List<String> Function(List<String> args, String compLine, int compPoint)
+  Iterable<String> Function(List<String> args, String compLine, int compPoint)
   completer, {
   @Deprecated('Useful for testing, but do not release with this set.')
   bool? logFile,
@@ -57,7 +57,7 @@ int? tryCompletionImpl(
 
     logLine(' *' * 50);
 
-    Logger.root.onRecord.listen((e) {
+    Logger.root.onRecord.listen((LogRecord e) {
       final loggerName = e.loggerName.split('.');
       if (loggerName.isNotEmpty && loggerName.first == 'completion') {
         loggerName.removeAt(0);

--- a/test/env_var_test.dart
+++ b/test/env_var_test.dart
@@ -4,50 +4,50 @@ import 'package:test/test.dart';
 void main() {
   group('tryCompletion environment parsing', () {
     test('missing COMP_LINE returns 1', () {
-      final args = ['completion', '--', 'exe'];
+      final args = <String>['completion', '--', 'exe'];
       final exitCode = tryCompletionImpl(
         args,
-        (a, l, p) => [],
-        environment: {},
+        (List<String> a, String l, int p) => <String>[],
+        environment: <String, String>{},
       );
       expect(exitCode, 1);
     });
 
     test('missing COMP_POINT returns 1', () {
-      final args = ['completion', '--', 'exe'];
+      final args = <String>['completion', '--', 'exe'];
       final exitCode = tryCompletionImpl(
         args,
-        (a, l, p) => [],
-        environment: {'COMP_LINE': 'exe '},
+        (List<String> a, String l, int p) => <String>[],
+        environment: <String, String>{'COMP_LINE': 'exe '},
       );
       expect(exitCode, 1);
     });
 
     test('valid completion returns 0', () {
-      final args = ['completion', '--', 'exe', 'a'];
-      final exitCode = tryCompletionImpl(args, (a, l, p) {
+      final args = <String>['completion', '--', 'exe', 'a'];
+      final exitCode = tryCompletionImpl(args, (List<String> a, String l, int p) {
         expect(l, 'exe a');
         expect(p, 5);
-        return ['completion'];
-      }, environment: {'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
+        return <String>['completion'];
+      }, environment: <String, String>{'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
       expect(exitCode, 0);
     });
 
     test('no completion args returns null', () {
-      final args = ['not-completion'];
+      final args = <String>['not-completion'];
       final exitCode = tryCompletionImpl(
         args,
-        (a, l, p) => [],
-        environment: {},
+        (List<String> a, String l, int p) => <String>[],
+        environment: <String, String>{},
       );
       expect(exitCode, isNull);
     });
 
     test('exception in completer returns 1', () {
-      final args = ['completion', '--', 'exe', 'a'];
-      final exitCode = tryCompletionImpl(args, (a, l, p) {
+      final args = <String>['completion', '--', 'exe', 'a'];
+      final exitCode = tryCompletionImpl(args, (List<String> a, String l, int p) {
         throw StateError('Test exception');
-      }, environment: {'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
+      }, environment: <String, String>{'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
       expect(exitCode, 1);
     });
   });

--- a/test/env_var_test.dart
+++ b/test/env_var_test.dart
@@ -25,11 +25,15 @@ void main() {
 
     test('valid completion returns 0', () {
       final args = <String>['completion', '--', 'exe', 'a'];
-      final exitCode = tryCompletionImpl(args, (List<String> a, String l, int p) {
-        expect(l, 'exe a');
-        expect(p, 5);
-        return <String>['completion'];
-      }, environment: <String, String>{'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
+      final exitCode = tryCompletionImpl(
+        args,
+        (List<String> a, String l, int p) {
+          expect(l, 'exe a');
+          expect(p, 5);
+          return <String>['completion'];
+        },
+        environment: <String, String>{'COMP_LINE': 'exe a', 'COMP_POINT': '5'},
+      );
       expect(exitCode, 0);
     });
 
@@ -45,9 +49,13 @@ void main() {
 
     test('exception in completer returns 1', () {
       final args = <String>['completion', '--', 'exe', 'a'];
-      final exitCode = tryCompletionImpl(args, (List<String> a, String l, int p) {
-        throw StateError('Test exception');
-      }, environment: <String, String>{'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
+      final exitCode = tryCompletionImpl(
+        args,
+        (List<String> a, String l, int p) {
+          throw StateError('Test exception');
+        },
+        environment: <String, String>{'COMP_LINE': 'exe a', 'COMP_POINT': '5'},
+      );
       expect(exitCode, 1);
     });
   });


### PR DESCRIPTION
I have optimized the argument completion logic by removing unnecessary `List` allocations. By changing the return type of `getArgsCompletions` and the `completer` callback to `Iterable<String>`, we avoid multiple $O(N)$ allocations per completion request. I also removed an intermediate list used for option alignment, opting for on-demand lookups which are efficient and further reduce memory pressure. Additionally, I addressed several `strict-inference` static analysis warnings that were present in the modified files.

---
*PR created automatically by Jules for task [8102278011421877583](https://jules.google.com/task/8102278011421877583) started by @kevmoo*