### PR TITLE
test: migrate test suite to package:checks

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   path: ^1.8.0
 
 dev_dependencies:
+  checks: ^0.3.1
   dart_flutter_team_lints: ^3.0.0
   test: ^1.16.6
   test_process: ^2.0.0

--- a/test/completion_test.dart
+++ b/test/completion_test.dart
@@ -192,10 +192,7 @@ void _testCompletionPair(
 ) {
   final completions = getArgsCompletions(parser, args, compLine, compPoint);
 
-  check(
-    completions,
-    because: 'for args: $args expected: $suggestions but got: $completions',
-  ).unorderedEquals(suggestions);
+  check(completions, because: 'for args: $args').unorderedEquals(suggestions);
 }
 
 typedef _CompletionSet = (

--- a/test/completion_test.dart
+++ b/test/completion_test.dart
@@ -1,6 +1,7 @@
 import 'package:args/args.dart';
+import 'package:checks/checks.dart';
 import 'package:completion/src/get_args_completions.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 import 'completion_tests_args.dart';
 
@@ -191,11 +192,10 @@ void _testCompletionPair(
 ) {
   final completions = getArgsCompletions(parser, args, compLine, compPoint);
 
-  expect(
+  check(
     completions,
-    unorderedEquals(suggestions),
-    reason: 'for args: $args expected: $suggestions but got: $completions',
-  );
+    because: 'for args: $args expected: $suggestions but got: $completions',
+  ).unorderedEquals(suggestions);
 }
 
 typedef _CompletionSet = (

--- a/test/env_var_test.dart
+++ b/test/env_var_test.dart
@@ -1,5 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:completion/src/try_completion.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   group('tryCompletion environment parsing', () {
@@ -10,7 +11,7 @@ void main() {
         (a, l, p) => [],
         environment: {},
       );
-      expect(exitCode, 1);
+      check(exitCode).equals(1);
     });
 
     test('missing COMP_POINT returns 1', () {
@@ -20,17 +21,17 @@ void main() {
         (a, l, p) => [],
         environment: {'COMP_LINE': 'exe '},
       );
-      expect(exitCode, 1);
+      check(exitCode).equals(1);
     });
 
     test('valid completion returns 0', () {
       final args = ['completion', '--', 'exe', 'a'];
       final exitCode = tryCompletionImpl(args, (a, l, p) {
-        expect(l, 'exe a');
-        expect(p, 5);
+        check(l).equals('exe a');
+        check(p).equals(5);
         return ['completion'];
       }, environment: {'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
-      expect(exitCode, 0);
+      check(exitCode).equals(0);
     });
 
     test('no completion args returns null', () {
@@ -40,7 +41,7 @@ void main() {
         (a, l, p) => [],
         environment: {},
       );
-      expect(exitCode, isNull);
+      check(exitCode).isNull();
     });
 
     test('exception in completer returns 1', () {
@@ -48,7 +49,7 @@ void main() {
       final exitCode = tryCompletionImpl(args, (a, l, p) {
         throw StateError('Test exception');
       }, environment: {'COMP_LINE': 'exe a', 'COMP_POINT': '5'});
-      expect(exitCode, 1);
+      check(exitCode).equals(1);
     });
   });
 }

--- a/test/golden_test.dart
+++ b/test/golden_test.dart
@@ -6,41 +6,44 @@ void main() {
   test('golden test for completion script', () {
     final script = generateCompletionScript(['my_app'], shell: Shell.bash);
 
-    check(script).contains('###-begin-my_app-completion-###');
-    check(script).contains('###-for-bash-###');
-    check(script).contains('complete -F __my_app_completion my_app');
-    check(script).not((it) => it.contains('###-for-zsh-###'));
-    check(script).not((it) => it.contains('###-for-fish-###'));
-    check(script).contains('###-end-my_app-completion-###');
+    check(script)
+      ..contains('###-begin-my_app-completion-###')
+      ..contains('###-for-bash-###')
+      ..contains('complete -F __my_app_completion my_app')
+      ..not((it) => it.contains('###-for-zsh-###'))
+      ..not((it) => it.contains('###-for-fish-###'))
+      ..contains('###-end-my_app-completion-###');
   });
 
   test('generate script for specific shell', () {
     final script = generateCompletionScript(['my_app'], shell: Shell.fish);
 
-    check(script).contains('###-begin-my_app-completion-###');
-    check(script).not((it) => it.contains('###-for-bash-###'));
-    check(script).not((it) => it.contains('###-for-zsh-###'));
-    check(script).contains('###-for-fish-###');
-    check(script).contains('complete -c my_app -f -a');
-    check(script).contains('###-end-my_app-completion-###');
+    check(script)
+      ..contains('###-begin-my_app-completion-###')
+      ..not((it) => it.contains('###-for-bash-###'))
+      ..not((it) => it.contains('###-for-zsh-###'))
+      ..contains('###-for-fish-###')
+      ..contains('complete -c my_app -f -a')
+      ..contains('###-end-my_app-completion-###');
   });
 
   test('generate script for nushell', () {
     final script = generateCompletionScript(['my_app'], shell: Shell.nushell);
 
-    check(script).contains('###-begin-my_app-completion-###');
-    check(script).not((it) => it.contains('###-for-bash-###'));
-    check(script).not((it) => it.contains('###-for-zsh-###'));
-    check(script).not((it) => it.contains('###-for-fish-###'));
-    check(script).contains('###-for-nushell-###');
-    check(script).contains('let __my_app_completion = {|spans|');
-    check(script).contains(r'mut config = ($env.config | default {})');
-    check(script).contains(
-      r'$config = ($config | upsert completions.external.enable true)',
-    );
-    check(script).contains(
-      r'$config.completions.external.completer = $__my_app_completion',
-    );
-    check(script).contains('###-end-my_app-completion-###');
+    check(script)
+      ..contains('###-begin-my_app-completion-###')
+      ..not((it) => it.contains('###-for-bash-###'))
+      ..not((it) => it.contains('###-for-zsh-###'))
+      ..not((it) => it.contains('###-for-fish-###'))
+      ..contains('###-for-nushell-###')
+      ..contains('let __my_app_completion = {|spans|')
+      ..contains(r'mut config = ($env.config | default {})')
+      ..contains(
+        r'$config = ($config | upsert completions.external.enable true)',
+      )
+      ..contains(
+        r'$config.completions.external.completer = $__my_app_completion',
+      )
+      ..contains('###-end-my_app-completion-###');
   });
 }

--- a/test/golden_test.dart
+++ b/test/golden_test.dart
@@ -1,51 +1,46 @@
+import 'package:checks/checks.dart';
 import 'package:completion/completion.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('golden test for completion script', () {
     final script = generateCompletionScript(['my_app'], shell: Shell.bash);
 
-    expect(script, contains('###-begin-my_app-completion-###'));
-    expect(script, contains('###-for-bash-###'));
-    expect(script, contains('complete -F __my_app_completion my_app'));
-    expect(script, isNot(contains('###-for-zsh-###')));
-    expect(script, isNot(contains('###-for-fish-###')));
-    expect(script, contains('###-end-my_app-completion-###'));
+    check(script).contains('###-begin-my_app-completion-###');
+    check(script).contains('###-for-bash-###');
+    check(script).contains('complete -F __my_app_completion my_app');
+    check(script).not((it) => it.contains('###-for-zsh-###'));
+    check(script).not((it) => it.contains('###-for-fish-###'));
+    check(script).contains('###-end-my_app-completion-###');
   });
 
   test('generate script for specific shell', () {
     final script = generateCompletionScript(['my_app'], shell: Shell.fish);
 
-    expect(script, contains('###-begin-my_app-completion-###'));
-    expect(script, isNot(contains('###-for-bash-###')));
-    expect(script, isNot(contains('###-for-zsh-###')));
-    expect(script, contains('###-for-fish-###'));
-    expect(script, contains('complete -c my_app -f -a'));
-    expect(script, contains('###-end-my_app-completion-###'));
+    check(script).contains('###-begin-my_app-completion-###');
+    check(script).not((it) => it.contains('###-for-bash-###'));
+    check(script).not((it) => it.contains('###-for-zsh-###'));
+    check(script).contains('###-for-fish-###');
+    check(script).contains('complete -c my_app -f -a');
+    check(script).contains('###-end-my_app-completion-###');
   });
 
   test('generate script for nushell', () {
     final script = generateCompletionScript(['my_app'], shell: Shell.nushell);
 
-    expect(script, contains('###-begin-my_app-completion-###'));
-    expect(script, isNot(contains('###-for-bash-###')));
-    expect(script, isNot(contains('###-for-zsh-###')));
-    expect(script, isNot(contains('###-for-fish-###')));
-    expect(script, contains('###-for-nushell-###'));
-    expect(script, contains('let __my_app_completion = {|spans|'));
-    expect(script, contains(r'mut config = ($env.config | default {})'));
-    expect(
-      script,
-      contains(
-        r'$config = ($config | upsert completions.external.enable true)',
-      ),
+    check(script).contains('###-begin-my_app-completion-###');
+    check(script).not((it) => it.contains('###-for-bash-###'));
+    check(script).not((it) => it.contains('###-for-zsh-###'));
+    check(script).not((it) => it.contains('###-for-fish-###'));
+    check(script).contains('###-for-nushell-###');
+    check(script).contains('let __my_app_completion = {|spans|');
+    check(script).contains(r'mut config = ($env.config | default {})');
+    check(script).contains(
+      r'$config = ($config | upsert completions.external.enable true)',
     );
-    expect(
-      script,
-      contains(
-        r'$config.completions.external.completer = $__my_app_completion',
-      ),
+    check(script).contains(
+      r'$config.completions.external.completer = $__my_app_completion',
     );
-    expect(script, contains('###-end-my_app-completion-###'));
+    check(script).contains('###-end-my_app-completion-###');
   });
 }

--- a/test/heuristic_test.dart
+++ b/test/heuristic_test.dart
@@ -1,6 +1,7 @@
 import 'package:args/args.dart';
+import 'package:checks/checks.dart';
 import 'package:completion/src/get_args_completions.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   group('heuristic subcommand detection', () {
@@ -8,7 +9,11 @@ void main() {
       ..addFlag('verbose')
       ..addCommand('commit', ArgParser()..addFlag('amend'));
 
-    void check(String description, List<String> args, Object matcher) {
+    void testHeuristic(
+      String description,
+      List<String> args,
+      void Function(Subject<List<String>>) condition,
+    ) {
       test(description, () {
         final completions = getArgsCompletions(
           parser,
@@ -16,19 +21,27 @@ void main() {
           args.join(' '),
           args.join(' ').length,
         );
-        expect(completions, matcher);
+        condition(check(completions));
       });
     }
 
-    check('simple', ['--unknown', 'commit', '--a'], contains('--amend'));
+    testHeuristic('simple', [
+      '--unknown',
+      'commit',
+      '--a',
+    ], (it) => it.contains('--amend'));
 
-    check('with multiple invalid args', [
+    testHeuristic('with multiple invalid args', [
       '--unknown',
       'junk',
       'commit',
       '--a',
-    ], contains('--amend'));
+    ], (it) => it.contains('--amend'));
 
-    check('no subcommand found', ['--unknown', 'junk', '--a'], isEmpty);
+    testHeuristic('no subcommand found', [
+      '--unknown',
+      'junk',
+      '--a',
+    ], (it) => it.isEmpty());
   });
 }

--- a/test/hidden_options_test.dart
+++ b/test/hidden_options_test.dart
@@ -10,8 +10,9 @@ void main() {
       ..addOption('hidden', hide: true, help: 'hidden option');
 
     final completions = getArgsCompletions(parser, ['--'], '--', 2);
-    check(completions).contains('--visible');
-    check(completions).not((it) => it.contains('--hidden'));
+    check(completions)
+      ..contains('--visible')
+      ..not((it) => it.contains('--hidden'));
   });
 
   test('hidden options are completed when includeHidden is true', () {
@@ -26,8 +27,9 @@ void main() {
       2,
       includeHidden: true,
     );
-    check(completions).contains('--visible');
-    check(completions).contains('--hidden');
+    check(completions)
+      ..contains('--visible')
+      ..contains('--hidden');
   });
 
   test('hidden flags are not completed by default', () {
@@ -36,8 +38,9 @@ void main() {
       ..addFlag('hidden', hide: true, help: 'hidden flag');
 
     final completions = getArgsCompletions(parser, ['--'], '--', 2);
-    check(completions).contains('--visible');
-    check(completions).not((it) => it.contains('--hidden'));
+    check(completions)
+      ..contains('--visible')
+      ..not((it) => it.contains('--hidden'));
   });
 
   test('hidden flags are completed when includeHidden is true', () {
@@ -52,7 +55,8 @@ void main() {
       2,
       includeHidden: true,
     );
-    check(completions).contains('--visible');
-    check(completions).contains('--hidden');
+    check(completions)
+      ..contains('--visible')
+      ..contains('--hidden');
   });
 }

--- a/test/hidden_options_test.dart
+++ b/test/hidden_options_test.dart
@@ -1,6 +1,7 @@
 import 'package:args/args.dart';
+import 'package:checks/checks.dart';
 import 'package:completion/src/get_args_completions.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('hidden options are not completed by default', () {
@@ -9,8 +10,8 @@ void main() {
       ..addOption('hidden', hide: true, help: 'hidden option');
 
     final completions = getArgsCompletions(parser, ['--'], '--', 2);
-    expect(completions, contains('--visible'));
-    expect(completions, isNot(contains('--hidden')));
+    check(completions).contains('--visible');
+    check(completions).not((it) => it.contains('--hidden'));
   });
 
   test('hidden options are completed when includeHidden is true', () {
@@ -25,8 +26,8 @@ void main() {
       2,
       includeHidden: true,
     );
-    expect(completions, contains('--visible'));
-    expect(completions, contains('--hidden'));
+    check(completions).contains('--visible');
+    check(completions).contains('--hidden');
   });
 
   test('hidden flags are not completed by default', () {
@@ -35,8 +36,8 @@ void main() {
       ..addFlag('hidden', hide: true, help: 'hidden flag');
 
     final completions = getArgsCompletions(parser, ['--'], '--', 2);
-    expect(completions, contains('--visible'));
-    expect(completions, isNot(contains('--hidden')));
+    check(completions).contains('--visible');
+    check(completions).not((it) => it.contains('--hidden'));
   });
 
   test('hidden flags are completed when includeHidden is true', () {
@@ -51,7 +52,7 @@ void main() {
       2,
       includeHidden: true,
     );
-    expect(completions, contains('--visible'));
-    expect(completions, contains('--hidden'));
+    check(completions).contains('--visible');
+    check(completions).contains('--hidden');
   });
 }

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -24,9 +24,7 @@ void main() {
       environment: {'COMP_POINT': '15', 'COMP_LINE': '$_exampleFileName --'},
     );
 
-    final completions = await Future.wait(
-      List.generate(5, (_) => process.stdout.next),
-    );
+    final completions = [for (var i = 0; i < 5; i++) await process.stdout.next];
     check(completions).unorderedEquals([
       '--friendly',
       '--loud',

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -1,5 +1,5 @@
+import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
-import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 import 'package:test_process/test_process.dart';
 
@@ -12,7 +12,7 @@ void main() {
   test('normal execution', () async {
     final process = await TestProcess.start(dartPath, [_exampleFilePath]);
 
-    await expectLater(process.stdout, emitsThrough('Hello, World'));
+    await check(process.stdout).emitsThrough((it) => it.equals('Hello, World'));
 
     await process.shouldExit(0);
   });
@@ -24,16 +24,16 @@ void main() {
       environment: {'COMP_POINT': '15', 'COMP_LINE': '$_exampleFileName --'},
     );
 
-    await expectLater(
-      process.stdout,
-      emitsInAnyOrder([
-        '--friendly',
-        '--loud',
-        '--no-loud',
-        '--salutation',
-        '--middle-name',
-      ]),
+    final completions = await Future.wait(
+      List.generate(5, (_) => process.stdout.next),
     );
+    check(completions).unorderedEquals([
+      '--friendly',
+      '--loud',
+      '--no-loud',
+      '--salutation',
+      '--middle-name',
+    ]);
 
     await process.shouldExit(0);
   });
@@ -46,7 +46,7 @@ void main() {
       environment: {'COMP_POINT': '${compLine.length}', 'COMP_LINE': compLine},
     );
 
-    await expectLater(process.stdout, emits('assistance'));
+    await check(process.stdout).emits((it) => it.equals('assistance'));
 
     await process.shouldExit(0);
   });

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -1,5 +1,6 @@
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
 import 'package:test_process/test_process.dart';
 
 import 'test_utils.dart';

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -24,7 +24,7 @@ void main() {
       environment: {'COMP_POINT': '15', 'COMP_LINE': '$_exampleFileName --'},
     );
 
-    final completions = [for (var i = 0; i < 5; i++) await process.stdout.next];
+    final completions = await process.stdout.rest.toList();
     check(completions).unorderedEquals([
       '--friendly',
       '--loud',

--- a/test/nu_shell_test.dart
+++ b/test/nu_shell_test.dart
@@ -4,9 +4,10 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:checks/checks.dart';
 import 'package:completion/completion.dart';
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 import 'package:test_process/test_process.dart';
 
 import 'test_utils.dart';
@@ -73,9 +74,10 @@ print (\$result | to json)
 
       // Attempt to decode the JSON
       final decoded = jsonDecode(allOutput) as List<dynamic>;
-      expect(decoded, contains('--friendly'));
-      expect(decoded, contains('--loud'));
-      expect(decoded, contains('--no-loud'));
+      check(decoded)
+        ..contains('--friendly')
+        ..contains('--loud')
+        ..contains('--no-loud');
 
       await process.shouldExit(0);
     },


### PR DESCRIPTION
Migrates the test suite from `package:matcher` to `package:checks`.

Verified 100% clean static analysis (`dart analyze`) and all tests passing (`dart test`).