### PR TITLE
style: format markdown files with 80-column line wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@
 - Added `includeHidden` parameter to `tryArgsCompletion` and
   `getArgsCompletions` to allow opting into showing hidden items.
 - Added heuristic subcommand detection to `getArgsCompletions`. When parsing
-  fails due to invalid arguments (e.g. typos, partially typed flags), the
-  system now attempts to identify known subcommands later in the argument list.
-  This allows completion to recover and provide suggestions for valid
-  subcommands even when earlier parts of the command line are incorrect.
+  fails due to invalid arguments (e.g. typos, partially typed flags), the system
+  now attempts to identify known subcommands later in the argument list. This
+  allows completion to recover and provide suggestions for valid subcommands
+  even when earlier parts of the command line are incorrect.
 
 ## 1.0.2
 
@@ -34,73 +34,75 @@
 
 ## 0.2.3
 
-* Prevent `tryCompletion` from crashing when looking up the script name when run
+- Prevent `tryCompletion` from crashing when looking up the script name when run
   without a current working directory.
 
 ## 0.2.2
 
-* Increase minimum Dart SDK to `2.3.0`.
+- Increase minimum Dart SDK to `2.3.0`.
 
 ## 0.2.1+1
 
-* Small fix to error handler.
+- Small fix to error handler.
 
 ## 0.2.1
 
-* Exposed the `tryCompletion` method as a public interface.
+- Exposed the `tryCompletion` method as a public interface.
 
-* Added more complete instructions in the [`README.md`](README.md)
+- Added more complete instructions in the [`README.md`](README.md)
 
 ## 0.2.0
 
-* Renamed `COMPLETION_COMMAND_NAME` to `completionCommandName`.
+- Renamed `COMPLETION_COMMAND_NAME` to `completionCommandName`.
 
-* Added named `logFile` argument to `tryArgsCompletion` and `tryCompletion` to
+- Added named `logFile` argument to `tryArgsCompletion` and `tryCompletion` to
   aid debugging.
 
 ## 0.1.6
 
-* A bunch of internal cleanup.
+- A bunch of internal cleanup.
 
 ## 0.1.5
 
-* Support the latest version of `logging`.
+- Support the latest version of `logging`.
 
 ## 0.1.4
 
-* Don't blow up if run via `pub run`.
+- Don't blow up if run via `pub run`.
 
 ## 0.1.2+5
 
-* Fix for latest `args` version.
+- Fix for latest `args` version.
 
 ## 0.1.2+4
 
-* Allow latest `args` version.
+- Allow latest `args` version.
 
 ## 0.1.2+3
 
-* Code cleanup.
+- Code cleanup.
 
 ## 0.1.2+2
 
-* Stopped using deprecated features from `bot` package.
+- Stopped using deprecated features from `bot` package.
 
-* Formatting
+- Formatting
 
 ## 0.1.2+1
 
- * Updated `hop` and added `hop_unittest` dev dependencies.
+- Updated `hop` and added `hop_unittest` dev dependencies.
 
 ## 0.1.2
 
-* Fixed test runner.
+- Fixed test runner.
 
 ## 0.1.1 2014-03-04
- * Removed unneeded dependency on `bot_io`
- * Cleanup of other references to `bot_io`
+
+- Removed unneeded dependency on `bot_io`
+- Cleanup of other references to `bot_io`
 
 ## 0.1.0 2014-02-15 (SDK 1.2.0-dev.5.7 32688)
- * First release
- * Maintains 100% compatibility with the `completion` library from the `bot_io`
-   package as of release `0.25.1+2`.
+
+- First release
+- Maintains 100% compatibility with the `completion` library from the `bot_io`
+  package as of release `0.25.1+2`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*Add shell command completion to your Dart console applications.*
+_Add shell command completion to your Dart console applications._
 
 [![Dart CI](https://github.com/kevmoo/completion.dart/actions/workflows/ci.yml/badge.svg)](https://github.com/kevmoo/completion.dart/actions/workflows/ci.yml)
 [![pub package](https://img.shields.io/pub/v/completion.svg)](https://pub.dev/packages/completion)
@@ -31,13 +31,14 @@ void main(List<String> args) {
 }
 ```
 
-(The only difference is calling `complete.tryArgsCompletion` in place of `argParser.parse`)
+(The only difference is calling `complete.tryArgsCompletion` in place of
+`argParser.parse`)
 
-This will add a "completion" command to your app, which the shell will use
-to complete arguments.
+This will add a "completion" command to your app, which the shell will use to
+complete arguments.
 
-To generate the setup script automatically, call `generateCompletionScript`
-with the names of the executables that your Dart script runs as (typically
-just one, but it could be more), along with the target `Shell`.
+To generate the setup script automatically, call `generateCompletionScript` with
+the names of the executables that your Dart script runs as (typically just one,
+but it could be more), along with the target `Shell`.
 
 Also, see [the example](./example).


### PR DESCRIPTION
- Wrap markdown prose within 80 columns using Prettier/mdf.
- Normalize bullet markers and standardize block whitespace.
