### PR TITLE
refactor: avoid calling exit() directly in tryArgsCompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.0.0-wip
 
-- **BREAKING** `tryCompletion` no longer calls `exit()`. Instead, it returns an
-  `int?` which is the exit code. A value of `null` indicates that the arguments
-  provided did not trigger completion. Callers must now handle the return value.
+- **BREAKING** `tryArgsCompletion` and `tryCompletion` no longer call `exit()`.
+  - `tryArgsCompletion` now sets `exitCode` and returns `ArgResults?` (`null` when completion was handled).
+  - `tryCompletion` returns an `int?` which is the exit code (`null` when completion was not triggered).
 - **BREAKING** The output of `generateCompletionScript` has been rewritten to
   generate a script for a single shell at a time, and now requires a `shell`
   argument to select which shell to generate a script for.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ void main(List<String> args) {
   final argParser = ArgParser()..addFlag('option', help: 'flag help');
   // ... add more options ...
   final argResults = completion.tryArgsCompletion(args, argParser);
+  if (argResults == null) return;
   // ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ void main(List<String> args) {
 }
 ```
 
-(The only difference is calling `complete.tryArgsCompletion` in place of
-`argParser.parse`)
+(The main difference is calling `completion.tryArgsCompletion` in place of
+`argParser.parse` and returning early when it returns `null`.)
 
 This will add a "completion" command to your app, which the shell will use to
 complete arguments.

--- a/example/example.dart
+++ b/example/example.dart
@@ -20,8 +20,8 @@ void main(List<String> args) {
     );
   } on FormatException catch (ex) {
     // TODO: print color?
-    print(ex.message);
-    print(argParser.usage);
+    stderr.writeln(ex.message);
+    stderr.writeln(argParser.usage);
 
     /// 64 - C/C++ standard for bad usage.
     exitCode = 64;

--- a/example/example.dart
+++ b/example/example.dart
@@ -10,7 +10,7 @@ import '../test/completion_tests_args.dart';
 void main(List<String> args) {
   final argParser = getHelloSampleParser();
 
-  ArgResults argResult;
+  ArgResults? argResult;
 
   try {
     argResult = tryArgsCompletion(
@@ -25,6 +25,10 @@ void main(List<String> args) {
 
     /// 64 - C/C++ standard for bad usage.
     exitCode = 64;
+    return;
+  }
+
+  if (argResult == null) {
     return;
   }
 

--- a/lib/src/try_args_completion.dart
+++ b/lib/src/try_args_completion.dart
@@ -8,8 +8,8 @@ import 'try_completion.dart';
 /// Try to complete the command line arguments.
 ///
 /// If [mainArgs] indicate that completion is requested, this function will
-/// print the completion suggestions to standard output and call [exit] with
-/// the suggested exit code.
+/// print the completion suggestions to standard output, set [exitCode] to
+/// the suggested exit code, and return `null`.
 ///
 /// If [mainArgs] do not indicate that completion is requested, this function
 /// will return the arguments parsed with [parser].
@@ -20,7 +20,7 @@ import 'try_completion.dart';
 /// If [includeHidden] is `true`, options marked as hidden will be included in
 /// the completion suggestions.
 /// (Hidden commands are always included.)
-ArgResults tryArgsCompletion(
+ArgResults? tryArgsCompletion(
   List<String> mainArgs,
   ArgParser parser, {
   @Deprecated('Useful for testing, but do not released with this set.')
@@ -41,10 +41,8 @@ ArgResults tryArgsCompletion(
   );
 
   if (suggestedExitCode != null) {
-    // Generally, one does NOT want to call `exit` in a library, but this is
-    // the only way to signal to the shell that completion was successful
-    // and to terminate the process.
-    exit(suggestedExitCode);
+    exitCode = suggestedExitCode;
+    return null;
   }
 
   return parser.parse(mainArgs);

--- a/lib/src/try_args_completion.dart
+++ b/lib/src/try_args_completion.dart
@@ -23,7 +23,7 @@ import 'try_completion.dart';
 ArgResults? tryArgsCompletion(
   List<String> mainArgs,
   ArgParser parser, {
-  @Deprecated('Useful for testing, but do not released with this set.')
+  @Deprecated('Useful for testing, but do not release with this set.')
   bool? logFile,
   bool includeHidden = false,
 }) {

--- a/test/env_var_test.dart
+++ b/test/env_var_test.dart
@@ -10,11 +10,13 @@ void main() {
   group('tryArgsCompletion', () {
     test('returns null and sets exitCode without calling exit()', () {
       final parser = ArgParser()..addFlag('verbose');
+      final originalExitCode = exitCode;
+      addTearDown(() => exitCode = originalExitCode);
+
       exitCode = 0;
       final result = tryArgsCompletion(['completion', '--', 'exe'], parser);
       check(result).isNull();
       check(exitCode).equals(1);
-      exitCode = 0;
     });
 
     test('returns parsed ArgResults when completion is not requested', () {

--- a/test/env_var_test.dart
+++ b/test/env_var_test.dart
@@ -1,8 +1,30 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
 import 'package:checks/checks.dart';
+import 'package:completion/completion.dart';
 import 'package:completion/src/try_completion.dart';
 import 'package:test/scaffolding.dart';
 
 void main() {
+  group('tryArgsCompletion', () {
+    test('returns null and sets exitCode without calling exit()', () {
+      final parser = ArgParser()..addFlag('verbose');
+      exitCode = 0;
+      final result = tryArgsCompletion(['completion', '--', 'exe'], parser);
+      check(result).isNull();
+      check(exitCode).equals(1);
+      exitCode = 0;
+    });
+
+    test('returns parsed ArgResults when completion is not requested', () {
+      final parser = ArgParser()..addFlag('verbose');
+      final result = tryArgsCompletion(['--verbose'], parser);
+      check(result).isNotNull();
+      check(result!['verbose'] as bool).isTrue();
+    });
+  });
+
   group('tryCompletion environment parsing', () {
     test('missing COMP_LINE returns 1', () {
       final args = ['completion', '--', 'exe'];


### PR DESCRIPTION
- Make tryArgsCompletion return ArgResults? and set exitCode instead of calling exit().
- Update example/example.dart, README.md, and CHANGELOG.md.
- Add unit tests in test/env_var_test.dart verifying tryArgsCompletion sets exitCode and returns null without terminating the isolate.

Fixes #82
